### PR TITLE
hash IDs for all entries into a consecutive range

### DIFF
--- a/include/gtfs/agency.hpp
+++ b/include/gtfs/agency.hpp
@@ -22,7 +22,7 @@ struct Agency
     std::string name;
     std::string url;
     std::string timezone;
-    boost::optional<std::string> id;
+    boost::optional<AgencyID> id;
     boost::optional<std::string> language;
     boost::optional<std::string> phone;
     boost::optional<std::string> fare_url;

--- a/include/gtfs/constructor.hpp
+++ b/include/gtfs/constructor.hpp
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "tool/container/id_hasher.hpp"
+
 #include <boost/assert.hpp>
 #include <boost/optional.hpp>
 
@@ -35,13 +37,13 @@ template <typename string_constructable> string_constructable constructFromStrin
 template <typename IDType> IDType stringToID(std::string id)
 {
     BOOST_ASSERT(id != "");
-    return IDType{static_cast<std::uint64_t>(std::stoll(id))};
+    return transit::tool::container::id_hash::get_id<IDType>(id, "default");
 }
 
 template <typename IDType> boost::optional<IDType> stringToOptionalID(std::string id)
 {
     if (!id.empty())
-        return {IDType{static_cast<std::uint64_t>(std::stoll(id))}};
+        return {stringToID<IDType>(id)};
     else
         return boost::none;
 }

--- a/include/tool/container/id_hasher.hpp
+++ b/include/tool/container/id_hasher.hpp
@@ -1,0 +1,44 @@
+#ifndef TRANSIT_TOOL_CONTAINER_ID_HASHER_HPP_
+#define TRANSIT_TOOL_CONTAINER_ID_HASHER_HPP_
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace transit
+{
+namespace tool
+{
+namespace container
+{
+
+// the ID hahser generates a new ID for any potential type we can have and that is provided in
+// string form. Since IDs have to be unique over all entries, the hasher is implemented as a
+// singleton. IDs can be generated from a combination of source and ID string. The hasher will take
+// care that all IDs will be unique.
+
+namespace id_hash
+{
+template <typename ID_TYPE> // templated for the return type, to keep consecutive IDs per type
+ID_TYPE get_id(std::string const &id, std::string const &source)
+{
+    // initialised on first call, kept alive forever :)
+    static std::unordered_map<std::string, std::uint64_t> id_hash;
+    const std::string concatenated_string = source + "@" + id;
+
+    if (id_hash.count(concatenated_string))
+        return ID_TYPE{id_hash.find(concatenated_string)->second};
+    else
+    {
+        std::uint64_t new_id = id_hash.size();
+        id_hash.insert(std::make_pair(concatenated_string, new_id));
+        return ID_TYPE{new_id};
+    }
+}
+} // namespace id_hash
+
+} // namespace container
+} // namespace tool
+} // namespace transit
+
+#endif // TRANSIT_TOOL_CONTAINER_ID_HASHER_HPP_

--- a/src/gtfs/agency.cpp
+++ b/src/gtfs/agency.cpp
@@ -24,7 +24,7 @@ Agency makeAgency(std::map<std::string, std::size_t> const &header,
         construct<std::string>("agency_name", forward, header, values),
         construct<std::string>("agency_url", forward, header, values),
         construct<std::string>("agency_timezone", forward, header, values),
-        construct<boost::optional<std::string>>("agency_id", asOptionalString, header, values),
+        construct<boost::optional<AgencyID>>("agency_id", stringToOptionalID<AgencyID>, header, values),
         construct<boost::optional<std::string>>("agency_lang", asOptionalString, header, values),
         construct<boost::optional<std::string>>("agency_phone", asOptionalString, header, values),
         construct<boost::optional<std::string>>(

--- a/test/gtfs/construct.cc
+++ b/test/gtfs/construct.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(optional_id)
     BOOST_CHECK_EQUAL(transit::gtfs::stringToOptionalID<std::uint64_t>(""), boost::none);
     BOOST_CHECK_EQUAL(transit::gtfs::stringToOptionalID<std::uint64_t>(""), boost::none);
     auto optional_int = transit::gtfs::stringToOptionalID<std::uint64_t>("123");
-    BOOST_CHECK(optional_int && (*optional_int == 123));
+    BOOST_CHECK(optional_int && (*optional_int == 0));
 }
 
 BOOST_AUTO_TEST_CASE(not_in_header)

--- a/test/gtfs/import-csv.cc
+++ b/test/gtfs/import-csv.cc
@@ -47,7 +47,7 @@ void makeAgency(std::string const &name)
 
 void checkAgencyFixture(Agency const &agency)
 {
-    const auto valid_id = agency.id && *agency.id == "1";
+    const auto valid_id = agency.id && *agency.id == AgencyID{0};
     BOOST_CHECK(valid_id);
     const auto valid_name = agency.name == "S-Bahn Berlin GmbH";
     BOOST_CHECK(valid_name);
@@ -112,8 +112,10 @@ void checkStopFixture(std::vector<Stop> const &stops)
     // we expect exactly three stops, see above
     BOOST_CHECK_EQUAL(stops.size(), 3);
 
-    const auto valid_ids = (stops[0].id == StopID{8012716}) && (stops[1].id == StopID{8012717}) &&
-                           (stops[2].id == StopID{8012718});
+    // stops include parent stop ids in every location
+    const auto valid_ids = (stops[0].id == StopID{0}) && (stops[1].id == StopID{2}) &&
+                           (stops[2].id == StopID{4});
+
     BOOST_CHECK(valid_ids);
 
     const auto valid_codes = stops[0].code && (*stops[0].code == "123") && stops[1].code &&
@@ -144,9 +146,9 @@ void checkStopFixture(std::vector<Stop> const &stops)
     BOOST_CHECK(valid_types);
 
     const auto valid_parents =
-        stops[0].parent_station && (*stops[0].parent_station == StopID{550215}) &&
-        stops[1].parent_station && (*stops[1].parent_station == StopID{550216}) &&
-        stops[2].parent_station && (*stops[2].parent_station == StopID{550217});
+        stops[0].parent_station && (*stops[0].parent_station == StopID{1}) &&
+        stops[1].parent_station && (*stops[1].parent_station == StopID{3}) &&
+        stops[2].parent_station && (*stops[2].parent_station == StopID{5});
     BOOST_CHECK(valid_parents);
 
     const auto valid_descriptions =
@@ -154,9 +156,9 @@ void checkStopFixture(std::vector<Stop> const &stops)
         (*stops[1].description == "so beautiful") && !stops[2].description;
     BOOST_CHECK(valid_descriptions);
 
-    const auto valid_zones = stops[0].zone_id && (stops[0].zone_id == ZoneID{1}) &&
-                             stops[1].zone_id && (stops[1].zone_id == ZoneID{2}) &&
-                             stops[2].zone_id && (stops[2].zone_id == ZoneID{3});
+    const auto valid_zones = stops[0].zone_id && (stops[0].zone_id == ZoneID{0}) &&
+                             stops[1].zone_id && (stops[1].zone_id == ZoneID{1}) &&
+                             stops[2].zone_id && (stops[2].zone_id == ZoneID{2});
     BOOST_CHECK(valid_zones);
 
     const auto valid_urls =
@@ -194,8 +196,9 @@ void checkMinimalStopFixture(std::vector<Stop> const &stops)
     // we expect exactly three stops, see above
     BOOST_CHECK_EQUAL(stops.size(), 3);
 
-    const auto valid_ids = (stops[0].id == StopID{8012716}) && (stops[1].id == StopID{8012717}) &&
-                           (stops[2].id == StopID{8012718});
+    // minimal IDs do not conatin parent stop stations
+    const auto valid_ids = (stops[0].id == StopID{0}) && (stops[1].id == StopID{2}) &&
+                           (stops[2].id == StopID{4});
     BOOST_CHECK(valid_ids);
 
     const auto valid_names = (stops[0].name == "Rastow, Bahnhof") &&

--- a/test/tool/CMakeLists.txt
+++ b/test/tool/CMakeLists.txt
@@ -9,4 +9,5 @@ set(toolINCLUDES
 
 add_unit_test(tool_io io.cc "${toolLIBS}" "${toolINCLUDES}")
 add_unit_test(tool_id ids.cc "${toolLIBS}" "${toolINCLUDES}")
+add_unit_test(tool_id_hasher id_hasher.cc "${toolLIBS}" "${toolINCLUDES}")
 add_unit_test(tool_decode_csv decode_csv.cc "${toolLIBS}" "${toolINCLUDES}")

--- a/test/tool/id_hasher.cc
+++ b/test/tool/id_hasher.cc
@@ -1,0 +1,61 @@
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "gtfs/stop.hpp"
+#include "gtfs/agency.hpp"
+#include "gtfs/trip.hpp"
+#include "tool/container/id_hasher.hpp"
+
+// make sure we get a new main function here
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace transit::gtfs;
+
+const constexpr int num_ids = 10;
+
+BOOST_AUTO_TEST_CASE(handle_different_ids)
+{
+    std::vector<int> data(num_ids);
+    std::iota(data.begin(), data.end(), num_ids);
+    std::random_shuffle(data.begin(), data.end());
+
+    for (std::uint32_t i = 0; i < num_ids; ++i)
+        BOOST_CHECK_EQUAL(transit::tool::container::id_hash::get_id<AgencyID>(
+                              std::to_string(data[i]), "default"),
+                          AgencyID{i});
+
+    // make sure IDS don't change between hashes
+    for (std::uint32_t i = 0; i < num_ids; ++i)
+        BOOST_CHECK_EQUAL(transit::tool::container::id_hash::get_id<AgencyID>(
+                              std::to_string(data[i]), "default"),
+                          AgencyID{i});
+
+    // reshuffle, check if types actually get their own IDs
+    std::random_shuffle(data.begin(), data.end());
+    for (std::uint64_t i = 0; i < num_ids; ++i)
+        BOOST_CHECK_EQUAL(transit::tool::container::id_hash::get_id<StopID>(
+                              std::to_string(data[i]), "default"),
+                          StopID{i});
+}
+
+BOOST_AUTO_TEST_CASE(handle_different_sources)
+{
+    std::vector<int> data(num_ids);
+    std::iota(data.begin(), data.end(), num_ids);
+    std::random_shuffle(data.begin(), data.end());
+
+    for (std::uint32_t i = 0; i < num_ids; ++i)
+        BOOST_CHECK_EQUAL(transit::tool::container::id_hash::get_id<TripID>(
+                              std::to_string(data[i]), "default"),
+                          TripID{i});
+
+    std::random_shuffle(data.begin(), data.end());
+    // make sure IDS don't change between hashes
+    for (std::uint32_t i = 0; i < num_ids; ++i)
+        BOOST_CHECK_EQUAL(transit::tool::container::id_hash::get_id<TripID>(
+                              std::to_string(data[i]), "other_source"),
+                          TripID{i+num_ids});
+}


### PR DESCRIPTION
This PR introduces hashing into the CSV parsing.
GTFS IDs can be anything in text-form. To get a consistent numbering from 0-n, we add ID-based hashing.
The hashing can be used from multiple sources, as long as the networks are distinct.
A potential problem to figure out down the line is how to handle ingesting multiple sources and how to connect multiple networks.