### PR TITLE
add group by algorithm

### DIFF
--- a/include/algorithm/group_by.hpp
+++ b/include/algorithm/group_by.hpp
@@ -1,0 +1,30 @@
+#ifndef TRANSIT_ALGORITHM_GROUP_BY_HPP_
+#define TRANSIT_ALGORITHM_GROUP_BY_HPP_
+
+#include <algorithm>
+
+#include <boost/assert.hpp>
+
+namespace transit
+{
+namespace algorithm
+{
+
+// execute fn on all items that are considered equal in relation to predicate
+// begin/end needs to be sorted based on `pred`
+template <typename iterator_type, typename predicate, typename functor>
+functor grouped_by(iterator_type begin, iterator_type end, predicate pred, functor fn)
+{
+    BOOST_ASSERT(std::is_sorted(begin, end, pred));
+    while (begin != end)
+    {
+        auto range = std::equal_range(begin, end, *begin, pred);
+        (void)fn(range);
+        begin = range.second;
+    }
+    return fn;
+}
+}
+} // transit
+
+#endif // TRANSIT_ALGORITHM_GROUP_BY_HPP_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,3 +16,4 @@ endmacro()
 
 add_subdirectory(tool)
 add_subdirectory(gtfs)
+add_subdirectory(algorithm)

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(algorithmLIBS
+        ${Boost_LIBRARIES})
+
+set(algorithmINCLUDES
+        ${Boost_INCLUDE_DIRS})
+
+add_unit_test(group_by group_by.cc "${algorithmLIBS}" "${algorithmINCLUDES}")

--- a/test/algorithm/group_by.cc
+++ b/test/algorithm/group_by.cc
@@ -1,0 +1,34 @@
+#include "algorithm/group_by.hpp"
+
+#include <utility>
+#include <vector>
+
+#include <iostream>
+
+// make sure we get a new main function here
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(handle_unopened_streams)
+{
+    std::vector<int> data = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+
+    using itr = std::vector<int>::iterator;
+    using range = std::pair<itr, itr>;
+
+    std::vector<range> result;
+
+    const auto add_to_results = [&result](const range rng) { result.push_back(rng); };
+
+    transit::algorithm::grouped_by(
+        data.begin(),
+        data.end(),
+        [](const int value, const int candidate) { return value < candidate; },
+        add_to_results);
+
+    BOOST_CHECK_EQUAL(result.size(), 4ull);
+    BOOST_CHECK_EQUAL(std::distance(result[0].first, result[0].second), 1);
+    BOOST_CHECK_EQUAL(std::distance(result[1].first, result[1].second), 2);
+    BOOST_CHECK_EQUAL(std::distance(result[2].first, result[2].second), 3);
+    BOOST_CHECK_EQUAL(std::distance(result[3].first, result[3].second), 4);
+}


### PR DESCRIPTION
The group by algorithm will allow to more easily create structures out of the GTFS data. GTFS streams consist of a series of tables, all of which can usually be grouped by some classification.

For example stop times can be grouped into different trips by their trip ID. To enable easy creation of underlying data structures, this algorithmic interface allows to execute functors on groups of entries.