### PR TITLE
allow ingesting frequencies into departure tables

### DIFF
--- a/include/gtfs/time.hpp
+++ b/include/gtfs/time.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <string>
+#include <iostream>
 
 namespace transit
 {
@@ -28,6 +29,8 @@ class Time
     // shift time by seconds
     friend Time operator+(Time lhs, std::uint32_t seconds);
     friend Time operator+(std::uint32_t seconds, Time lhs);
+
+    friend std::ostream& operator<<(std::ostream &os, Time const& time);
 };
 
 std::uint32_t operator-(Time const &lhs, Time const &rhs);
@@ -37,6 +40,8 @@ bool operator==(Time const &lhs, Time const &rhs);
 
 Time operator+(Time lhs, std::uint32_t seconds);
 Time operator+(std::uint32_t seconds, Time lhs);
+
+std::ostream& operator<<(std::ostream &os, Time const& time);
 
 } // namespace gtfs
 } // namespace transit

--- a/include/timetable/departure_table.hpp
+++ b/include/timetable/departure_table.hpp
@@ -1,19 +1,55 @@
 #ifndef TRANSIT_TIMETABLE_DEPARTURETABLE_HPP_
 #define TRANSIT_TIMETABLE_DEPARTURETABLE_HPP_
 
+#include <cstdint>
+
+#include <boost/range/iterator_range.hpp>
+
+#include "gtfs/time.hpp"
+#include "gtfs/trip.hpp"
+
 namespace transit
 {
 namespace timetable
 {
 
-// Public transit routing consists of timetable routing. The departuretables define when connections leave certain stops. In
-// general these occurr in certain periodic settings. For any time at any stop we need to be able to access the next
-// connections that are possible. The departuretable itself assumes the stop, line, and the time of arrival are known and allows
-// quick access to the next connection of the given departure. It only represents a single line.
+class DepartureTableFactory;
+
+// Public transit routing consists of timetable routing. The departuretables define when connections
+// leave certain stops. In general these occurr in certain periodic settings. For any time at any
+// stop we need to be able to access the next connections that are possible. The departuretable
+// itself assumes the stop, line, and the time of arrival are known and allows  quick access to the
+// next connection of the given departure. It only represents a single line.
 class DepartureTable
 {
-    // give access to the next departure of the given departure
-    void next(/*time*/);
+  public:
+    struct Departure
+    {
+        gtfs::Time begin;
+        gtfs::Time end;
+        std::uint32_t headway;
+
+        bool operator<(Departure const &other) const;
+
+        gtfs::Time getNextDeparture(gtfs::Time const starting_at) const;
+    };
+
+    // iterator types
+    using const_iterator = std::vector<Departure>::const_iterator;
+    using const_iterator_range = boost::iterator_range<const_iterator>;
+
+    // access for construction
+    friend class DepartureTableFactory;
+
+    // access methods
+    gtfs::TripID trip_id() const { return _trip_id; }
+
+    // list all valid departures from a given time
+    const_iterator_range list(gtfs::Time starting_at) const;
+
+  private:
+    gtfs::TripID _trip_id;
+    std::vector<Departure> departures;
 };
 
 } // namespace timetable

--- a/include/timetable/departure_table_factory.hpp
+++ b/include/timetable/departure_table_factory.hpp
@@ -1,0 +1,23 @@
+#ifndef TRANSIT_TIMETABLE_DEPARTURE_TABLE_FACTORY_HPP
+#define TRANSIT_TIMETABLE_DEPARTURE_TABLE_FACTORY_HPP
+
+#include "gtfs/frequency.hpp"
+#include "timetable/departure_table.hpp"
+
+namespace transit
+{
+namespace timetable
+{
+
+class DepartureTableFactory
+{
+  public:
+    // create the departure table of stop_time based on frequencies
+    static DepartureTable produce(std::vector<gtfs::Frequency>::iterator begin,
+                                  std::vector<gtfs::Frequency>::iterator end);
+};
+
+} // namespace timetable
+} // namespace transit
+
+#endif // TRANSIT_TIMETABLE_DEPARTURE_TABLE_FACTORY_HPP

--- a/include/timetable/stop_table.hpp
+++ b/include/timetable/stop_table.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "gtfs/stop.hpp"
+#include "gtfs/trip.hpp"
 
 #include <boost/range/iterator_range.hpp>
 
@@ -35,12 +36,14 @@ class StopTable
     // list stations along the line, and their departure
     const_iterator_range list(gtfs::StopID start_id) const;
 
+    gtfs::TripID trip_id() const { return _trip_id; }
+
   private:
+    gtfs::TripID _trip_id;
     std::vector<Arrival> stop_arrivals;
 
     friend class StopTableFactory;
 };
-
 
 } // namespace timetable
 } // namespace transit

--- a/include/timetable/timetable.hpp
+++ b/include/timetable/timetable.hpp
@@ -1,8 +1,12 @@
 #ifndef TRANSIT_TIMETABLE_HPP_
 #define TRANSIT_TIMETABLE_HPP_
 
-
+#include "timetable/departure_table.hpp"
 #include "timetable/stop_table.hpp"
+
+#include "gtfs/trip.hpp"
+
+#include <boost/optional.hpp>
 
 namespace transit
 {
@@ -15,10 +19,23 @@ class TimeTableFactory;
 // essentially provides the graph and the travel times for the navigation algorithm
 class TimeTable
 {
-    public:
-        std::vector<StopTable> stop_tables;
+  public:
+    std::vector<StopTable> stop_tables;
+    std::vector<DepartureTable> departure_tables;
 
-    private:
+    // a trip is specified by the list of stops along its path and the departures from the first
+    // station
+    struct Trip
+    {
+        const StopTable &stops;
+        const DepartureTable &departures;
+
+        Trip(StopTable const &stops, DepartureTable const &departures);
+    };
+
+    boost::optional<Trip> get_trip(gtfs::TripID trip_id) const;
+
+  private:
     friend class TimeTableFactory;
 };
 

--- a/src/apps/csv-import.cpp
+++ b/src/apps/csv-import.cpp
@@ -2,11 +2,17 @@
 #include "gtfs/provider.hpp"
 #include "gtfs/read_csv.hpp"
 
+#include "gtfs/stop.hpp"
+#include "gtfs/time.hpp"
+#include "gtfs/trip.hpp"
+
 #include "timetable/timetable.hpp"
 #include "timetable/timetable_factory.hpp"
 
 #include <cstdlib>
 #include <iostream>
+
+using namespace transit;
 
 int main(int argc, char **argv) try
 {
@@ -14,6 +20,23 @@ int main(int argc, char **argv) try
     auto dataset = transit::gtfs::readCSV(source);
 
     auto timetable = transit::timetable::TimeTableFactory::produce(dataset);
+
+    auto trip = timetable.get_trip(gtfs::TripID{0});
+
+    if (trip)
+    {
+        gtfs::Time time("12:31:13");
+        for (auto const departure : trip->departures.list(time))
+        {
+            auto const depart = departure.getNextDeparture(time);
+            std::cout << "Departing at: " << depart << std::endl;
+            for (auto const stop : trip->stops.list(gtfs::StopID{0}))
+            {
+                std::cout << "\tHold: " << stop.stop_id << " at " << (depart + stop.delta_t)
+                          << std::endl;
+            }
+        }
+    }
 
     return EXIT_SUCCESS;
 }

--- a/src/gtfs/time.cpp
+++ b/src/gtfs/time.cpp
@@ -9,11 +9,10 @@ namespace gtfs
 {
 
 Time::Time() : seconds_since_midnight(0), interpolated(false) {}
-Time::Time(std::uint8_t hour, std::uint8_t minute, std::uint8_t second)
-    : interpolated(false)
+Time::Time(std::uint8_t hour, std::uint8_t minute, std::uint8_t second) : interpolated(false)
 {
     seconds_since_midnight = hour;
-    seconds_since_midnight *= 24;
+    seconds_since_midnight *= 60;
     seconds_since_midnight += minute;
     seconds_since_midnight *= 60;
     seconds_since_midnight += second;
@@ -33,7 +32,7 @@ Time::Time(std::string const &encoded_time)
         BOOST_ASSERT(end_hours_pos != std::string::npos);
         const auto end_hours = encoded_time.begin() + end_hours_pos;
         seconds_since_midnight = std::stoi(std::string(encoded_time.begin(), end_hours));
-        seconds_since_midnight *= 24;
+        seconds_since_midnight *= 60;
         seconds_since_midnight += std::stoi(std::string(end_hours + 1, end_hours + 3));
         seconds_since_midnight *= 60;
         seconds_since_midnight += std::stoi(std::string(end_hours + 4, encoded_time.end()));
@@ -69,6 +68,17 @@ Time operator+(std::uint32_t seconds, Time rhs)
 {
     rhs.seconds_since_midnight += seconds;
     return rhs;
+}
+
+std::ostream &operator<<(std::ostream &os, Time const &time)
+{
+    auto hours = time.seconds_since_midnight / 3600;
+    auto minutes = (time.seconds_since_midnight % 3600) / 60;
+    auto seconds = time.seconds_since_midnight % 60;
+
+    os << hours << ":" << (minutes < 10 ? "0" : "") << minutes << ":" << (seconds < 10 ? "0" : "")
+       << seconds;
+    return os;
 }
 
 } // namespace gtfs

--- a/src/timetable/CMakeLists.txt
+++ b/src/timetable/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(timetable_SOURCES
     stop_table_factory.cpp
     line_table.cpp
     departure_table.cpp
+    departure_table_factory.cpp
     timetable_factory.cpp
     timetable.cpp)
 

--- a/src/timetable/departure_table.cpp
+++ b/src/timetable/departure_table.cpp
@@ -1,11 +1,47 @@
 #include "timetable/departure_table.hpp"
 
+#include <algorithm>
+
+#include <boost/assert.hpp>
+
 namespace transit
 {
 namespace timetable
 {
 
-void DepartureTable::next(){}
+bool DepartureTable::Departure::operator<(DepartureTable::Departure const &other) const
+{
+    return end < other.end;
+}
+
+gtfs::Time DepartureTable::Departure::getNextDeparture(gtfs::Time const starting_at) const
+{
+    // the next departue for a given starting time is defined by T = begin + x * headway with T >=
+    // starting_at and x minimal among all x that fulfill T >= starting_at
+
+    BOOST_ASSERT(starting_at < end);
+
+    // in case the trip is only serviced after the starting time, the very first service can be
+    // reached. After this check starting_at is within the range [begin,end)
+    if (starting_at < begin)
+        return begin;
+
+    // compute the xth train that can be reached (ceil(delta_t/headway))
+    const auto x = (starting_at - begin + headway - 1) / headway;
+
+    return begin + x * headway;
+}
+
+DepartureTable::const_iterator_range DepartureTable::list(gtfs::Time starting_at) const
+{
+    return {std::lower_bound(departures.begin(),
+                             departures.end(),
+                             starting_at,
+                             [](auto const &departure, auto const &time) {
+                                 return departure.end < time + (departure.headway);
+                             }),
+            departures.end()};
+}
 
 } // namespace timetable
 } // namespace transit

--- a/src/timetable/departure_table_factory.cpp
+++ b/src/timetable/departure_table_factory.cpp
@@ -1,0 +1,54 @@
+#include "timetable/departure_table_factory.hpp"
+#include "timetable/exceptions.hpp"
+
+#include <algorithm>
+#include <boost/numeric/conversion/cast.hpp>
+
+namespace transit
+{
+namespace timetable
+{
+
+namespace
+{
+
+template <typename iterator_type>
+void check_input_validity(const iterator_type begin, const iterator_type end)
+{
+    if (!std::distance(begin, end))
+        throw InvalidInputError("Frequency factory called without frequencies.");
+
+    if (std::any_of(begin, end, [begin](auto const &frequency) {
+            return frequency.trip_id != begin->trip_id;
+        }))
+    {
+        throw InvalidInputError(
+            "Frequencies need to represent the same trip for departur table construction.");
+    }
+}
+
+} // namespace
+
+DepartureTable DepartureTableFactory::produce(std::vector<gtfs::Frequency>::iterator begin,
+                                              std::vector<gtfs::Frequency>::iterator end)
+{
+    DepartureTable table;
+    check_input_validity(begin, end);
+
+    table.departures.reserve(std::distance(begin, end));
+
+    const auto to_departure = [](auto const &frequency) -> DepartureTable::Departure {
+        return {
+            frequency.begin, frequency.end, boost::numeric_cast<std::uint32_t>(frequency.headway)};
+    };
+
+    std::transform(begin, end, std::back_inserter(table.departures), to_departure);
+
+    table._trip_id = begin->trip_id;
+
+    std::sort(table.departures.begin(), table.departures.end());
+    return table;
+}
+
+} // namespace timetable
+} // namespace transit

--- a/src/timetable/stop_table_factory.cpp
+++ b/src/timetable/stop_table_factory.cpp
@@ -91,6 +91,7 @@ StopTable StopTableFactory::produce(std::vector<gtfs::StopTime>::iterator begin,
 
     // transfer the arrival times to the stop table
     StopTable result;
+    result._trip_id = begin->trip_id;
     result.stop_arrivals = std::move(stop_arrivals);
     return result;
 }

--- a/src/timetable/timetable.cpp
+++ b/src/timetable/timetable.cpp
@@ -1,9 +1,33 @@
 #include "timetable/timetable.hpp"
 
+#include <algorithm>
+
 namespace transit
 {
 namespace timetable
 {
+
+TimeTable::Trip::Trip(StopTable const &stops, DepartureTable const &departures)
+    : stops(stops), departures(departures)
+{
+}
+
+boost::optional<TimeTable::Trip> TimeTable::get_trip(gtfs::TripID trip_id) const
+{
+    auto const by_id = [trip_id](auto const &table) { return trip_id == table.trip_id(); };
+
+    auto const stop = std::find_if(stop_tables.begin(), stop_tables.end(), by_id);
+
+    if (stop == stop_tables.end())
+        return boost::none;
+
+    auto const departure = std::find_if(departure_tables.begin(), departure_tables.end(), by_id);
+
+    if (departure == departure_tables.end())
+        return boost::none;
+    else
+        return Trip{*stop, *departure};
+}
 
 } // namespace timetable
 } // namespace transit

--- a/src/timetable/timetable_factory.cpp
+++ b/src/timetable/timetable_factory.cpp
@@ -1,4 +1,5 @@
 #include "timetable/timetable.hpp"
+#include "timetable/departure_table_factory.hpp"
 #include "timetable/stop_table_factory.hpp"
 #include "timetable/timetable_factory.hpp"
 
@@ -14,29 +15,55 @@ namespace transit
 namespace timetable
 {
 
+namespace
+{
+
+// template to produce items based on equal ranges in a sorted order
+template <typename factory,
+          typename result_type,
+          typename input_type,
+          typename sorting_predicate,
+          typename grouping_predicate>
+void produceByEqualRanges(std::vector<result_type> &output,
+                          std::vector<input_type> &input,
+                          sorting_predicate sort_by,
+                          grouping_predicate group_by)
+{
+    // ensure correct ordering.
+    std::stable_sort(input.begin(), input.end(), sort_by);
+
+    using InputIter = typename std::vector<input_type>::iterator;
+    using InputIterRange = std::pair<InputIter, InputIter>;
+
+    const auto output_inserter = [&output](InputIterRange const range) {
+        output.push_back(factory::produce(range.first, range.second));
+    };
+
+    algorithm::by_equal_ranges(input.begin(), input.end(), group_by, output_inserter);
+}
+
+} // namespace
+
 TimeTable TimeTableFactory::produce(gtfs::Dataset &dataset)
 {
     TimeTable result;
 
-    // ensure that trips are in correct order
-    std::sort(
-        dataset.stop_times.begin(), dataset.stop_times.end(), [](auto const &lhs, auto const &rhs) {
+    produceByEqualRanges<StopTableFactory>(
+        result.stop_tables,
+        dataset.stop_times,
+        [](auto const &lhs, auto const &rhs) {
             return std::tie(lhs.trip_id, lhs.sequence_id) < std::tie(rhs.trip_id, rhs.sequence_id);
+        },
+        [](gtfs::StopTime const &value, gtfs::StopTime const &candidate) {
+            return value.trip_id < candidate.trip_id;
         });
 
-    using StopTimeIter = decltype(dataset.stop_times)::iterator;
-    using StopTimeIterRange = std::pair<StopTimeIter, StopTimeIter>;
-
-    const auto stop_table_inserter = [&result](StopTimeIterRange const range) {
-        result.stop_tables.push_back(StopTableFactory::produce(range.first, range.second));
+    auto const by_trip_id = [](auto const &lhs, auto const &rhs) {
+        return lhs.trip_id < rhs.trip_id;
     };
-    const auto same_trip_id = [](gtfs::StopTime const &value, gtfs::StopTime const &candidate) {
-        return value.trip_id < candidate.trip_id;
-    };
-
-    // create stop tables for all trips
-    algorithm::by_equal_ranges(
-        dataset.stop_times.begin(), dataset.stop_times.end(), same_trip_id, stop_table_inserter);
+    if (dataset.frequencies)
+        produceByEqualRanges<DepartureTableFactory>(
+            result.departure_tables, *dataset.frequencies, by_trip_id, by_trip_id);
 
     return result;
 }

--- a/test/gtfs/time.cc
+++ b/test/gtfs/time.cc
@@ -1,4 +1,5 @@
 #include "gtfs/time.hpp"
+#include <sstream>
 
 // make sure we get a new main function here
 #define BOOST_TEST_MAIN
@@ -16,7 +17,7 @@ BOOST_AUTO_TEST_CASE(construct_time)
 BOOST_AUTO_TEST_CASE(check_normalisation)
 {
     transit::gtfs::Time time(0, 62, 65);
-    BOOST_CHECK_EQUAL(time.seconds_since_midnight, 62*60+65);
+    BOOST_CHECK_EQUAL(time.seconds_since_midnight, 62 * 60 + 65);
 }
 
 BOOST_AUTO_TEST_CASE(check_delta)
@@ -24,7 +25,7 @@ BOOST_AUTO_TEST_CASE(check_delta)
     transit::gtfs::Time lhs(1, 2, 3);
     transit::gtfs::Time rhs(2, 3, 4);
 
-    BOOST_CHECK_EQUAL(rhs - lhs, 24 * 60 + 60 + 1);
+    BOOST_CHECK_EQUAL(rhs - lhs, 3600 + 60 + 1);
 }
 
 BOOST_AUTO_TEST_CASE(interpolated)
@@ -54,7 +55,17 @@ BOOST_AUTO_TEST_CASE(check_addition)
 
     transit::gtfs::Time zero("00:00:00");
 
-    BOOST_CHECK(a+59 == b);
-    BOOST_CHECK(59+a ==  b);
-    BOOST_CHECK(a + (a-zero) == transit::gtfs::Time("00:00:02"));
+    BOOST_CHECK(a + 59 == b);
+    BOOST_CHECK(59 + a == b);
+    BOOST_CHECK(a + (a - zero) == transit::gtfs::Time("00:00:02"));
+}
+
+BOOST_AUTO_TEST_CASE(serialisation)
+{
+    transit::gtfs::Time a("00:00:01");
+    transit::gtfs::Time b("00:01:10");
+
+    std::ostringstream oss;
+    oss << a << " " << b;
+    BOOST_CHECK_EQUAL(oss.str().c_str(), "0:00:01 0:01:10");
 }

--- a/test/timetable/CMakeLists.txt
+++ b/test/timetable/CMakeLists.txt
@@ -9,4 +9,4 @@ set(timetableINCLUDES
         ${PROTOBUF_INCLUDE_DIRS})
 
 add_unit_test(timetable_stop_table stop_table.cc "${timetableLIBS}" "${timetableINCLUDES}")
-
+add_unit_test(timetable_departure_table departure_table.cc "${timetableLIBS}" "${timetableINCLUDES}")

--- a/test/timetable/stop_table.cc
+++ b/test/timetable/stop_table.cc
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(check_interpolation)
     // cannot use empty vectors
     std::vector<StopTime> data;
 
-    StopTime stop_time = {TripID{0},
+    StopTime stop_time = {TripID{42},
                       Time("00:10:00"),
                       Time("00:10:00"),
                       StopID{0},
@@ -105,6 +105,8 @@ BOOST_AUTO_TEST_CASE(check_interpolation)
     ++itr;
     BOOST_CHECK_EQUAL(itr->stop_id,StopID{2});
     BOOST_CHECK_EQUAL(itr->delta_t,600);
+
+    BOOST_CHECK_EQUAL(stop_table.trip_id(),TripID{42});
 }
 
 


### PR DESCRIPTION
Next step towards https://github.com/mapbox/directions-transit/issues/18. 

The departure tables ingest the gtfs::frequencies and create a table of available departures.