### PR TITLE
allow routing on stop_times alone. Frequencies are not needed

### DIFF
--- a/include/timetable/departure_table_factory.hpp
+++ b/include/timetable/departure_table_factory.hpp
@@ -2,6 +2,8 @@
 #define TRANSIT_TIMETABLE_DEPARTURE_TABLE_FACTORY_HPP
 
 #include "gtfs/frequency.hpp"
+#include "gtfs/stop.hpp"
+
 #include "timetable/departure_table.hpp"
 
 namespace transit
@@ -15,6 +17,10 @@ class DepartureTableFactory
     // create the departure table of stop_time based on frequencies
     static DepartureTable produce(std::vector<gtfs::Frequency>::iterator begin,
                                   std::vector<gtfs::Frequency>::iterator end);
+
+    // in case frequencies are not specified, we detect departures from the stop_time tables
+    static DepartureTable produce(std::vector<gtfs::StopTime>::iterator begin,
+                                  std::vector<gtfs::StopTime>::iterator end);
 };
 
 } // namespace timetable

--- a/src/apps/csv-import.cpp
+++ b/src/apps/csv-import.cpp
@@ -16,7 +16,8 @@ using namespace transit;
 
 int main(int argc, char **argv) try
 {
-    transit::gtfs::CSVDiscSource source("data/example");
+    //transit::gtfs::CSVDiscSource source("data/example");
+    transit::gtfs::CSVDiscSource source("data/berlin-gtfs");
     auto dataset = transit::gtfs::readCSV(source);
 
     auto timetable = transit::timetable::TimeTableFactory::produce(dataset);
@@ -25,7 +26,7 @@ int main(int argc, char **argv) try
 
     if (trip)
     {
-        gtfs::Time time("12:31:13");
+        gtfs::Time time("00:00:00");
         for (auto const departure : trip->departures.list(time))
         {
             auto const depart = departure.getNextDeparture(time);

--- a/src/timetable/departure_table_factory.cpp
+++ b/src/timetable/departure_table_factory.cpp
@@ -2,6 +2,7 @@
 #include "timetable/exceptions.hpp"
 
 #include <algorithm>
+
 #include <boost/numeric/conversion/cast.hpp>
 
 namespace transit
@@ -47,6 +48,19 @@ DepartureTable DepartureTableFactory::produce(std::vector<gtfs::Frequency>::iter
     table._trip_id = begin->trip_id;
 
     std::sort(table.departures.begin(), table.departures.end());
+    return table;
+}
+
+DepartureTable DepartureTableFactory::produce(std::vector<gtfs::StopTime>::iterator begin,
+                                              std::vector<gtfs::StopTime>::iterator end)
+{
+    DepartureTable table;
+    // at some time frequency / stop time might need different checks, right now we are fine doing
+    // it this way and miss-using the input validity template
+    check_input_validity(begin, end);
+
+    table._trip_id = begin->trip_id;
+    table.departures.push_back({begin->departure, begin->departure, 0u});
     return table;
 }
 

--- a/src/timetable/timetable_factory.cpp
+++ b/src/timetable/timetable_factory.cpp
@@ -62,8 +62,16 @@ TimeTable TimeTableFactory::produce(gtfs::Dataset &dataset)
         return lhs.trip_id < rhs.trip_id;
     };
     if (dataset.frequencies)
+    {
         produceByEqualRanges<DepartureTableFactory>(
             result.departure_tables, *dataset.frequencies, by_trip_id, by_trip_id);
+    }
+    else
+    {
+        // sort is stable, so we don't don anything to the stop_times here
+        produceByEqualRanges<DepartureTableFactory>(
+            result.departure_tables, dataset.stop_times, by_trip_id, by_trip_id);
+    }
 
     return result;
 }


### PR DESCRIPTION
Next step on making gtfs data usable for routing.
The previous iteration required a frequencies table for departure times.
With this change we can generate a departure table from stop times, allowing to find routes in the same way as before, only now generating the data from stop_times.

To simplify the departure table, which right now is a series of departure times rather than ranges of frequencies, we should investigate if it is possible to group departure times based on their associated stop times.

Since trip_ids are unique, we first need to merge departure times and filter stop_tables that serve the same route.