### PR TITLE
add basic annotation capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,10 @@ find_package(Protobuf 2.4.1 REQUIRED)
 add_subdirectory(src/tool)
 
 add_subdirectory(src/adaptor)
+add_subdirectory(src/annotation)
 add_subdirectory(src/geometric)
 add_subdirectory(src/gtfs)
+add_subdirectory(src/navigation)
 add_subdirectory(src/timetable)
 
 

--- a/include/annotation/stop_info.hpp
+++ b/include/annotation/stop_info.hpp
@@ -1,0 +1,35 @@
+#ifndef TRANSIT_ANNOTATION_STOP_INFO_HPP_
+#define TRANSIT_ANNOTATION_STOP_INFO_HPP_
+
+#include "geometric/coordinate.hpp"
+#include "gtfs/stop.hpp"
+#include "tool/container/dictionary.hpp"
+
+#include <vector>
+
+namespace transit
+{
+namespace annotation
+{
+
+struct StopInfo
+{
+    tool::container::DictionaryID name_id;
+    geometric::Coordinate location;
+};
+
+class StopInfoTable
+{
+  public:
+    StopInfoTable(std::vector<gtfs::Stop> &stops);
+
+    StopInfo get_info(gtfs::StopID const stop_id) const;
+
+  private:
+    std::vector<StopInfo> stop_info;
+};
+
+} // namespace annotation
+} // namespace transit
+
+#endif // TRANSIT_ANNOTATION_STOP_INFO_HPP_

--- a/include/annotation/trip.hpp
+++ b/include/annotation/trip.hpp
@@ -1,0 +1,30 @@
+#ifndef TRANSIT_ANNOTATION_TRIP_HPP_
+#define TRANSIT_ANNOTATION_TRIP_HPP_
+
+#include "annotation/stop_info.hpp"
+#include "navigation/trip.hpp"
+#include "tool/container/string_table.hpp"
+
+namespace transit
+{
+namespace annotation
+{
+
+class Trip
+{
+  public:
+    Trip(StopInfoTable const &stop_info, transit::tool::container::StringTable const &dictionary);
+
+    // should probably provide a json response at some time, right now we generate an annotated
+    // string
+    std::string operator()(navigation::Trip const &trip) const;
+
+  private:
+    StopInfoTable const &stop_info;
+    transit::tool::container::StringTable const &dictionary;
+};
+
+} // namespace annotation
+} // namespace transit
+
+#endif // TRANSIT_ANNOTATION_TRIP_HPP_

--- a/include/geometric/coordinate.hpp
+++ b/include/geometric/coordinate.hpp
@@ -2,8 +2,10 @@
 #define TRANSIT_GEOMETRIC_COORDINATE_HPP_
 
 #include <boost/serialization/strong_typedef.hpp>
+
 #include <cmath>
 #include <cstdint>
+#include <iostream>
 
 namespace transit
 {
@@ -15,8 +17,8 @@ namespace
 constexpr auto const COORDINATE_PRECISION = 1.0e06;
 }
 
-BOOST_STRONG_TYPEDEF(std::uint32_t, FixedLatitude)
-BOOST_STRONG_TYPEDEF(std::uint32_t, FixedLongitude)
+BOOST_STRONG_TYPEDEF(std::int32_t, FixedLatitude)
+BOOST_STRONG_TYPEDEF(std::int32_t, FixedLongitude)
 
 template <typename lat_or_long> lat_or_long makeLatLonFromDouble(double const value)
 {
@@ -28,9 +30,15 @@ class Coordinate
   public:
     Coordinate(FixedLongitude, FixedLatitude);
 
+    friend std::ostream &operator<<(std::ostream &os, Coordinate const &location);
+    friend bool operator==(Coordinate const&lhs, Coordinate const&rhs);
+
     FixedLongitude longitude;
     FixedLongitude latitude;
 };
+
+std::ostream &operator<<(std::ostream &os, Coordinate const &location);
+bool operator==(Coordinate const&lhs, Coordinate const&rhs);
 
 } // namespace geometric
 } // namespace transit

--- a/include/navigation/algorithm/timetable.hpp
+++ b/include/navigation/algorithm/timetable.hpp
@@ -1,0 +1,36 @@
+#ifndef TRANSIT_NAVIGATION_ALGORITHMS_TIMETABLE_HPP_
+#define TRANSIT_NAVIGATION_ALGORITHMS_TIMETABLE_HPP_
+
+#include "navigation/routing_algorithm.hpp"
+#include "timetable/timetable.hpp"
+
+#include "gtfs/stop.hpp"
+#include "gtfs/time.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+namespace algorithm
+{
+
+class TimeTable : public RoutingAlgorithm
+{
+  public:
+    TimeTable(timetable::TimeTable const &time_table);
+
+    // query a route between two stops
+    Trip operator()(gtfs::Time const departure,
+                    gtfs::StopID const origin,
+                    gtfs::StopID const destination) const override final;
+
+  private:
+    // the unmodified timetable data to route on
+    timetable::TimeTable const &time_table;
+};
+
+} // namespace algorithm
+} // namespace navigation
+} // namespace transit
+
+#endif // TRANSIT_NAVIGATION_ALGORITHMS_TIMETABLE_HPP_

--- a/include/navigation/leg.hpp
+++ b/include/navigation/leg.hpp
@@ -1,0 +1,45 @@
+#ifndef TRANSIT_NAVIGATION_LEG_HPP_
+#define TRANSIT_NAVIGATION_LEG_HPP_
+
+#include <cstdint>
+#include <vector>
+
+#include <boost/range/iterator_range.hpp>
+
+#include "timetable/stop_table.hpp"
+#include "gtfs/time.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+
+// forward declaration for friend access
+class RoutingAlgorithm;
+
+// within a trip, a leg describes a single segment between two distinct transfers. A leg can be a
+// single connection (e.g. take the 100 from A to B), or a series of possible connections.
+// We can immagine taking any of a series of busses, depending on which one we manage to catch in
+// case of close connections. In that case we would offer take any of 100/101/231 from A to B
+class Leg
+{
+  public:
+    using stop_type = timetable::StopTable::Arrival;
+    using iterator = std::vector<stop_type>::const_iterator;
+
+    boost::iterator_range<iterator> list() const;
+    gtfs::Time departure() const;
+
+  private:
+    gtfs::Time _departure;
+    // the stops along the leg
+    std::vector<stop_type> stops;
+
+    // make sure routing algorithms are allowed to construct legs
+    friend class RoutingAlgorithm;
+};
+
+} // namespace navigation
+} // namespace transit
+
+#endif // TRANSIT_NAVIGATION_LEG_HPP_

--- a/include/navigation/routing_algorithm.hpp
+++ b/include/navigation/routing_algorithm.hpp
@@ -1,0 +1,31 @@
+#ifndef TRANSIT_NAVIGATION_ROUTING_ALGORITHM_HPP
+#define TRANSIT_NAVIGATION_ROUTING_ALGORITHM_HPP
+
+#include "gtfs/stop.hpp"
+#include "gtfs/time.hpp"
+#include "navigation/trip.hpp"
+#include "navigation/leg.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+
+// interface for all routing algorithms to implement
+class RoutingAlgorithm
+{
+  public:
+    virtual Trip operator()(gtfs::Time const departure,
+                            gtfs::StopID const origin,
+                            gtfs::StopID const destination) const = 0;
+
+  protected:
+    void add_leg(Trip &trip, Leg leg) const;
+    void add_stop(Leg &leg, Leg::stop_type stop) const;
+    void set_departure(Leg &leg, gtfs::Time time) const;
+};
+
+} // namespace navigation
+} // namespace transit
+
+#endif // TRANSIT_NAVIGATION_ROUTING_ALGORITHM_HPP

--- a/include/navigation/trip.hpp
+++ b/include/navigation/trip.hpp
@@ -1,0 +1,34 @@
+#ifndef TRANSIT_NAVIGATION_TRIP_HPP_
+#define TRANSIT_NAVIGATION_TRIP_HPP_
+
+#include "navigation/leg.hpp"
+
+#include <boost/range/iterator_range.hpp>
+
+namespace transit
+{
+namespace navigation
+{
+
+// forward declaration for friend access
+class RoutingAlgorithm;
+
+// A trip is the result of a navigation query. It describes a number of stops / transits along a
+// route. The trip is the result of a earliest arrival query
+class Trip
+{
+    public:
+        using iterator = std::vector<Leg>::const_iterator;
+
+        boost::iterator_range<iterator> list() const;
+    private:
+        std::vector<Leg> legs;
+
+    // make sure routing algorithms are allowed to construct trips
+    friend class RoutingAlgorithm;
+};
+
+} // namespace navigation
+} // namespace transit
+
+#endif // TRANSIT_NAVIGATION_TRIP_HPP_

--- a/src/annotation/CMakeLists.txt
+++ b/src/annotation/CMakeLists.txt
@@ -1,0 +1,18 @@
+# define a set of sources to compile
+set(annotate_SOURCES
+    stop_info.cpp
+    trip.cpp)
+
+# export source files as library
+add_library(transitannotate STATIC
+    ${annotate_SOURCES})
+
+# link all required items
+target_link_libraries(transitannotate
+    ${Boost_LIBRARIES}
+    transitproto)
+
+# define additional include directories
+target_include_directories(transitannotate SYSTEM PUBLIC
+    ${Boost_INCLUDE_DIRS}
+    ${PROTOBUF_INCLUDE_DIRS})

--- a/src/annotation/stop_info.cpp
+++ b/src/annotation/stop_info.cpp
@@ -1,0 +1,36 @@
+#include "annotation/stop_info.hpp"
+
+#include <algorithm>
+#include <boost/assert.hpp>
+#include <iterator>
+
+namespace transit
+{
+namespace annotation
+{
+
+StopInfoTable::StopInfoTable(std::vector<gtfs::Stop> &stops)
+{
+    std::sort(stops.begin(), stops.end(), [](auto const &lhs, auto const &rhs) {
+        return lhs.id < rhs.id;
+    });
+
+    stop_info.reserve(stops.size());
+
+    // add all stop entries to the stop_info vector
+    std::transform(stops.begin(),
+                   stops.end(),
+                   std::back_inserter(stop_info),
+                   [this](auto const &stop) -> StopInfo {
+                       BOOST_ASSERT(stop_info.size() == static_cast<std::uint64_t>(stop.id));
+                       return {stop.name, stop.location};
+                   });
+}
+
+StopInfo StopInfoTable::get_info(gtfs::StopID const stop_id) const
+{
+    return stop_info[static_cast<std::uint64_t>(stop_id)];
+}
+
+} // namespace annotation
+} // namespace transit

--- a/src/annotation/trip.cpp
+++ b/src/annotation/trip.cpp
@@ -1,0 +1,38 @@
+#include "annotation/trip.hpp"
+
+#include <sstream>
+
+namespace transit
+{
+namespace annotation
+{
+
+Trip::Trip(StopInfoTable const &stop_info, transit::tool::container::StringTable const &dictionary)
+    : stop_info(stop_info), dictionary(dictionary)
+{
+}
+
+// annotate a trip with all required information. This should be replaced with a json result/what
+// ever we want for our api.
+std::string Trip::operator()(navigation::Trip const &trip) const
+{
+    std::ostringstream oss;
+
+    // Write out information about a trip
+    for (auto const &leg : trip.list())
+    {
+        oss << "[Leg]\n";
+        for (auto const &hold : leg.list())
+        {
+            auto const info = stop_info.get_info(hold.stop_id);
+            oss << "\t" << (leg.departure() + hold.delta_t) << " at stop: " << hold.stop_id
+                << " name: " << dictionary.get_string(info.name_id)
+                << " located at: " << info.location << "\n";
+        }
+    }
+
+    return oss.str();
+}
+
+} // namespace annotation
+} // namespace transit

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -9,11 +9,13 @@ target_link_libraries(csv-import
     ${LIBZMQ_LIBRARIES}
     ${MAYBE_COVERAGE_LIBRARIES}
     transitadaptor
+    transitannotate
     transitproto
     transittool
     transitgtfs
-    transittimetable
-    transitgeometric)
+    transitgeometric
+    transitnavigation
+    transittimetable)
 
 target_include_directories(csv-import SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}

--- a/src/geometric/coordinate.cpp
+++ b/src/geometric/coordinate.cpp
@@ -10,5 +10,17 @@ Coordinate::Coordinate(FixedLongitude longitude_, FixedLatitude latitude_)
 {
 }
 
+std::ostream &operator<<(std::ostream &os, Coordinate const &location)
+{
+    os << static_cast<std::int32_t>(location.longitude) / COORDINATE_PRECISION << " "
+       << static_cast<std::int32_t>(location.latitude) / COORDINATE_PRECISION;
+    return os;
+}
+
+bool operator==(Coordinate const &lhs, Coordinate const &rhs)
+{
+    return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
+}
+
 } // namespace geometric
 } // namespace transit

--- a/src/navigation/CMakeLists.txt
+++ b/src/navigation/CMakeLists.txt
@@ -1,6 +1,10 @@
 # define a set of sources to compile
 SET(navigation_SOURCES
-    )
+    leg.cpp
+    trip.cpp
+    routing_algorithm.cpp
+    algorithm/timetable.cpp)
+
 # export source files as library
 ADD_LIBRARY(transitnavigation
     ${navigation_SOURCES})

--- a/src/navigation/algorithm/timetable.cpp
+++ b/src/navigation/algorithm/timetable.cpp
@@ -1,0 +1,41 @@
+#include "navigation/algorithm/timetable.hpp"
+#include "navigation/leg.hpp"
+
+#include "gtfs/stop.hpp"
+#include "gtfs/time.hpp"
+#include "gtfs/trip.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+namespace algorithm
+{
+
+TimeTable::TimeTable(timetable::TimeTable const &time_table) : time_table(time_table) {}
+
+Trip TimeTable::operator()(gtfs::Time const departure,
+                           gtfs::StopID const origin,
+                           gtfs::StopID const destination) const
+{
+    Trip result;
+    auto trip = time_table.get_trip(gtfs::TripID{0});
+    if (trip)
+    {
+        for (auto const trip_departure : trip->departures.list(departure))
+        {
+            Leg leg;
+
+            set_departure(leg, trip_departure.getNextDeparture(departure));
+            for (auto const stop : trip->stops.list(origin))
+                add_stop(leg, stop);
+
+            add_leg(result, std::move(leg));
+        }
+    }
+    return result;
+}
+
+} // namespace algorithm
+} // namespace navigation
+} // namespace transit

--- a/src/navigation/leg.cpp
+++ b/src/navigation/leg.cpp
@@ -1,0 +1,19 @@
+#include "navigation/leg.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+
+boost::iterator_range<Leg::iterator> Leg::list() const
+{
+    return boost::make_iterator_range(stops.begin(),stops.end());
+}
+
+gtfs::Time Leg::departure() const
+{
+    return _departure;
+}
+
+} // namespace navigation
+} // namespace transit

--- a/src/navigation/routing_algorithm.cpp
+++ b/src/navigation/routing_algorithm.cpp
@@ -1,0 +1,24 @@
+#include "navigation/routing_algorithm.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+
+void RoutingAlgorithm::add_leg(Trip &trip, Leg leg) const
+{
+    trip.legs.push_back(std::move(leg));
+}
+
+void RoutingAlgorithm::add_stop(Leg &leg, Leg::stop_type stop) const
+{
+    leg.stops.push_back(std::move(stop));
+}
+
+void RoutingAlgorithm::set_departure(Leg &leg, gtfs::Time time) const
+{
+    leg._departure = time;
+}
+
+} // namespace navigation
+} // namespace transit

--- a/src/navigation/trip.cpp
+++ b/src/navigation/trip.cpp
@@ -1,0 +1,14 @@
+#include "navigation/trip.hpp"
+
+namespace transit
+{
+namespace navigation
+{
+
+boost::iterator_range<Trip::iterator> Trip::list() const
+{
+    return boost::make_iterator_range(legs.begin(), legs.end());
+}
+
+} // namespace navigation
+} // namespace transit

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,8 @@ endmacro()
 
 add_subdirectory(adaptor)
 add_subdirectory(algorithm)
+add_subdirectory(annotation)
+add_subdirectory(geometric)
 add_subdirectory(gtfs)
 add_subdirectory(timetable)
 add_subdirectory(tool)

--- a/test/adaptor/CMakeLists.txt
+++ b/test/adaptor/CMakeLists.txt
@@ -4,8 +4,6 @@ set(adaptorLIBS
         transitproto
         transittool)
 
-message(STATUS "PBF: " ${PROTOBUF_LITE_LIBRARIES})
-
 set(adaptorINCLUDES
         ${Boost_INCLUDE_DIRS}
         ${PROTOBUF_INCLUDE_DIRS})

--- a/test/annotation/CMakeLists.txt
+++ b/test/annotation/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(annotationLIBS
+        ${Boost_LIBRARIES}
+        transitannotate
+        transitgtfs
+        transitadaptor
+        transittool)
+
+set(annotationINCLUDES
+        ${Boost_INCLUDE_DIRS}
+        ${PROTOBUF_INCLUDE_DIRS})
+
+add_unit_test(annotation_stop_info stop_info.cc "${annotationLIBS}" "${annotationINCLUDES}")

--- a/test/annotation/stop_info.cc
+++ b/test/annotation/stop_info.cc
@@ -1,0 +1,78 @@
+#include <string>
+#include <vector>
+
+#include "annotation/stop_info.hpp"
+#include "geometric/coordinate.hpp"
+#include "gtfs/stop.hpp"
+
+#include "adaptor/dictionary.hpp"
+#include "tool/container/dictionary.hpp"
+#include "tool/container/string_table.hpp"
+
+using namespace transit::annotation;
+using namespace transit::gtfs;
+using namespace transit::tool::container;
+using namespace transit::geometric;
+
+// make sure we get a new main function here
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+namespace
+{
+Stop make_stop(std::uint64_t i, DictionaryID s, transit::geometric::Coordinate c)
+{
+    return {StopID{i},
+            s,
+            c,
+            boost::none,
+            boost::none,
+            boost::none,
+            boost::none,
+            boost::none,
+            boost::none,
+            boost::none,
+            boost::none};
+}
+};
+
+BOOST_AUTO_TEST_CASE(annotate_stops)
+{
+    std::vector<Stop> stops;
+    Dictionary dictionary;
+    Coordinate coordinate(makeLatLonFromDouble<FixedLongitude>(1.1),
+                          makeLatLonFromDouble<FixedLatitude>(1.1));
+    Coordinate coordinate2(makeLatLonFromDouble<FixedLongitude>(2.1),
+                           makeLatLonFromDouble<FixedLatitude>(2.1));
+    Coordinate coordinate3(makeLatLonFromDouble<FixedLongitude>(3.1),
+                           makeLatLonFromDouble<FixedLatitude>(3.1));
+    Coordinate coordinate4(makeLatLonFromDouble<FixedLongitude>(4.1),
+                           makeLatLonFromDouble<FixedLatitude>(4.1));
+
+    stops.push_back(make_stop(0, dictionary.add_string("first"), coordinate));
+    stops.push_back(make_stop(1, dictionary.add_string("second"), coordinate2));
+    stops.push_back(make_stop(2, dictionary.add_string("third"), coordinate3));
+    stops.push_back(make_stop(3, dictionary.add_string("fourth"), coordinate4));
+
+    StringTable table;
+    transit::adaptor::Dictionary::decode_into(table,
+                                              transit::adaptor::Dictionary::encode(dictionary));
+
+    StopInfoTable stop_info(stops);
+
+    auto first = stop_info.get_info(StopID{0ull});
+    BOOST_CHECK_EQUAL(first.location, coordinate);
+    BOOST_CHECK_EQUAL(table.get_string(first.name_id), "first");
+
+    auto second = stop_info.get_info(StopID{1ull});
+    BOOST_CHECK_EQUAL(second.location, coordinate2);
+    BOOST_CHECK_EQUAL(table.get_string(second.name_id), "second");
+
+    auto third = stop_info.get_info(StopID{2ull});
+    BOOST_CHECK_EQUAL(third.location, coordinate3);
+    BOOST_CHECK_EQUAL(table.get_string(third.name_id), "third");
+
+    auto fourth = stop_info.get_info(StopID{3ull});
+    BOOST_CHECK_EQUAL(fourth.location, coordinate4);
+    BOOST_CHECK_EQUAL(table.get_string(fourth.name_id), "fourth");
+}

--- a/test/geometric/CMakeLists.txt
+++ b/test/geometric/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(geometricLIBS
+        ${Boost_LIBRARIES}
+        transitgeometric)
+
+set(geometricINCLUDES
+        ${Boost_INCLUDE_DIRS}
+        ${PROTOBUF_INCLUDE_DIRS})
+
+add_unit_test(geometric_coordinate coordinate.cc "${geometricLIBS}" "${geometricINCLUDES}")

--- a/test/geometric/coordinate.cc
+++ b/test/geometric/coordinate.cc
@@ -1,0 +1,34 @@
+#include <sstream>
+
+#include "geometric/coordinate.hpp"
+
+using namespace transit::geometric;
+
+// make sure we get a new main function here
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(coordinate_construction)
+{
+    Coordinate coordinate(makeLatLonFromDouble<FixedLongitude>(1.1),
+                          makeLatLonFromDouble<FixedLatitude>(1.1));
+
+    Coordinate coordinate2(makeLatLonFromDouble<FixedLongitude>(1.1),
+                           makeLatLonFromDouble<FixedLatitude>(1.1));
+
+    Coordinate coordinate3(makeLatLonFromDouble<FixedLongitude>(-1.1),
+                           makeLatLonFromDouble<FixedLatitude>(-1.1));
+
+    BOOST_CHECK(coordinate == coordinate2);
+    {
+        std::ostringstream oss;
+        oss << coordinate;
+        BOOST_CHECK_EQUAL(oss.str(), "1.1 1.1");
+    }
+
+    {
+        std::ostringstream oss;
+        oss << coordinate3;
+        BOOST_CHECK_EQUAL(oss.str(), "-1.1 -1.1");
+    }
+}


### PR DESCRIPTION
At some point, we need to be able to fill internal datastructures with meaning for humans. A simple example here is stop_ids, which are perfect for internal work, but kind of useless to providing a journey. A single trip from a to be needs to be augmented with additional information that make it readable to a human.

E.g. a transfer `StopID 1, RouteID 1, RouteID 2` could become `at main station change from the red to the yellow line`.

This PR adds the basic functionality to allow annotation based on a string dictionary. We start off with very basic leg, but this functionality will be possible to augment along the way to produce actually meaningful output.