### PR TITLE
Revert "Added lovely animation to README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # directions-transit
 This repository is going to host everything for a Mapbox public transit api in terms of backend / bindings
 
-<img src="http://i.imgur.com/q5fSpYU.gifv" alt="Why?"/>
-
 [![Build Status](https://travis-ci.com/mapbox/directions-transit.svg?token=bB1pwxscyosgCFnSzzds&branch=master)](https://travis-ci.com/mapbox/directions-transit)
 [![codecov](https://codecov.io/gh/mapbox/directions-transit/branch/master/graph/badge.svg?token=yDJlm8LLSU)](https://codecov.io/gh/mapbox/directions-transit)
 


### PR DESCRIPTION
Reverts mapbox/directions-transit#43

@danpat the image does not show up in the readme, when merged.

<img width="930" alt="screen shot 2017-03-17 at 09 58 54" src="https://cloud.githubusercontent.com/assets/12932279/24036092/63aa8a26-0af8-11e7-819d-2e122906fd7a.png">

Clicking on the image returns `Non-Image content-type returned`.


