### PR TITLE
explicityly set syntax of proto files to proto2 syntax

### DIFF
--- a/src/tool/proto/accessibility.proto
+++ b/src/tool/proto/accessibility.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message WheelchairAccessibility

--- a/src/tool/proto/agency.proto
+++ b/src/tool/proto/agency.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Agency

--- a/src/tool/proto/calendar.proto
+++ b/src/tool/proto/calendar.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message CalendarDate

--- a/src/tool/proto/coordinate.proto
+++ b/src/tool/proto/coordinate.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Coordinate

--- a/src/tool/proto/dictionary.proto
+++ b/src/tool/proto/dictionary.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.container;
 
 message DictionaryEntry {

--- a/src/tool/proto/fare.proto
+++ b/src/tool/proto/fare.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Fare

--- a/src/tool/proto/frequency.proto
+++ b/src/tool/proto/frequency.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Frequency

--- a/src/tool/proto/gtfs.proto
+++ b/src/tool/proto/gtfs.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 option optimize_for = LITE_RUNTIME;

--- a/src/tool/proto/route.proto
+++ b/src/tool/proto/route.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Route

--- a/src/tool/proto/schedule.proto
+++ b/src/tool/proto/schedule.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message WeeklySchedule

--- a/src/tool/proto/shape.proto
+++ b/src/tool/proto/shape.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 import "coordinate.proto";

--- a/src/tool/proto/stop.proto
+++ b/src/tool/proto/stop.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 import "accessibility.proto";

--- a/src/tool/proto/transfer.proto
+++ b/src/tool/proto/transfer.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 message Transfer

--- a/src/tool/proto/trip.proto
+++ b/src/tool/proto/trip.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package transit.io.gtfs.proto;
 
 import "accessibility.proto";


### PR DESCRIPTION
as said in title. The compiler for protobuf complains with warnings otherwise.