### PR TITLE
reduce warnings by implementing missing types in vector tile

### DIFF
--- a/include/tool/container/mapbox_vector_tile.hpp
+++ b/include/tool/container/mapbox_vector_tile.hpp
@@ -26,14 +26,16 @@ enum VectorTileValueType
 {
     BOOL,
     INT,
+    UINT,
     DOUBLE,
+    FLOAT,
     STRING
 };
 
 struct VectorTileValue
 {
     VectorTileValueType type;
-    boost::variant<bool, int, double, std::string> value;
+    boost::variant<bool, std::int64_t, std::uint64_t, double, float, std::string> value;
 
     // comparison so we can use a map
     bool operator==(VectorTileValue const &other) const;

--- a/test/tool/vector_tile.cc
+++ b/test/tool/vector_tile.cc
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "geometric/coordinate.hpp"
 #include "tool/container/mapbox_vector_tile.hpp"
@@ -17,8 +18,10 @@ VectorTileValue get_string(std::string const &string)
 {
     return {VectorTileValueType::STRING, string};
 }
-VectorTileValue get_int(int val) { return {VectorTileValueType::INT, val}; }
+VectorTileValue get_int(std::int64_t val) { return {VectorTileValueType::INT, val}; }
+VectorTileValue get_uint(std::uint64_t val) { return {VectorTileValueType::UINT, val}; }
 VectorTileValue get_double(double val) { return {VectorTileValueType::DOUBLE, val}; }
+VectorTileValue get_float(float val) { return {VectorTileValueType::FLOAT, val}; }
 VectorTileValue get_bool(bool flag) { return {VectorTileValueType::BOOL, flag}; }
 
 BOOST_AUTO_TEST_CASE(compare_strings)
@@ -41,11 +44,31 @@ BOOST_AUTO_TEST_CASE(compare_ints)
     BOOST_CHECK(a < b);
 }
 
+BOOST_AUTO_TEST_CASE(compare_uints)
+{
+    auto const a = get_uint(1);
+    auto const a2 = get_uint(1);
+    auto const b = get_uint(2);
+
+    BOOST_CHECK(a == a2);
+    BOOST_CHECK(a < b);
+}
+
 BOOST_AUTO_TEST_CASE(compare_double)
 {
     auto const a = get_double(1.);
     auto const a2 = get_double(1.);
     auto const b = get_double(2.);
+
+    BOOST_CHECK(a == a2);
+    BOOST_CHECK(a < b);
+}
+
+BOOST_AUTO_TEST_CASE(compare_float)
+{
+    auto const a = get_float(1.);
+    auto const a2 = get_float(1.);
+    auto const b = get_float(2.);
 
     BOOST_CHECK(a == a2);
     BOOST_CHECK(a < b);
@@ -65,30 +88,61 @@ BOOST_AUTO_TEST_CASE(compare_by_type)
 {
     auto const a = get_bool(true);
     auto const b = get_int(1);
-    auto const c = get_double(0.);
-    auto const d = get_string("hi");
+    auto const c = get_uint(1);
+    auto const d = get_double(0.);
+    auto const e = get_float(0.f);
+    auto const f = get_string("hi");
 
     BOOST_CHECK(!(a == b));
     BOOST_CHECK(!(a == c));
     BOOST_CHECK(!(a == d));
+    BOOST_CHECK(!(a == e));
+    BOOST_CHECK(!(a == f));
     BOOST_CHECK(!(b == a));
     BOOST_CHECK(!(b == c));
     BOOST_CHECK(!(b == d));
+    BOOST_CHECK(!(b == e));
+    BOOST_CHECK(!(b == f));
     BOOST_CHECK(!(c == a));
     BOOST_CHECK(!(c == b));
     BOOST_CHECK(!(c == d));
+    BOOST_CHECK(!(c == e));
+    BOOST_CHECK(!(c == f));
     BOOST_CHECK(!(d == a));
     BOOST_CHECK(!(d == b));
     BOOST_CHECK(!(d == c));
+    BOOST_CHECK(!(d == e));
+    BOOST_CHECK(!(d == f));
+    BOOST_CHECK(!(e == a));
+    BOOST_CHECK(!(e == b));
+    BOOST_CHECK(!(e == c));
+    BOOST_CHECK(!(e == d));
+    BOOST_CHECK(!(e == f));
+    BOOST_CHECK(!(f == a));
+    BOOST_CHECK(!(f == b));
+    BOOST_CHECK(!(f == c));
+    BOOST_CHECK(!(f == d));
+    BOOST_CHECK(!(f == e));
 
     BOOST_CHECK(a < b);
     BOOST_CHECK(a < c);
     BOOST_CHECK(a < d);
+    BOOST_CHECK(a < e);
+    BOOST_CHECK(a < f);
 
     BOOST_CHECK(b < c);
     BOOST_CHECK(b < d);
+    BOOST_CHECK(b < e);
+    BOOST_CHECK(b < f);
 
     BOOST_CHECK(c < d);
+    BOOST_CHECK(c < e);
+    BOOST_CHECK(c < f);
+
+    BOOST_CHECK(d < e);
+    BOOST_CHECK(d < f);
+
+    BOOST_CHECK(e < f);
 }
 
 BOOST_AUTO_TEST_CASE(write_values)
@@ -101,17 +155,21 @@ BOOST_AUTO_TEST_CASE(write_values)
             auto const one = get_int(3);
             auto const two = get_double(4.);
             auto const greet = get_string("hello world!");
+            auto const four = get_uint(5);
+            auto const five = get_float(1.1f);
 
             tr.write(tile_writer);
             one.write(tile_writer);
             two.write(tile_writer);
             greet.write(tile_writer);
+            four.write(tile_writer);
+            five.write(tile_writer);
         }
     }
     {
         protozero::pbf_reader reader(buffer);
         int messages = 0;
-        bool got_string = false, got_int = false, got_double = false, got_bool = false;
+        bool got_string = false, got_int = false, got_double = false, got_bool = false, got_uint = false, got_float = false;
         while (reader.next())
         {
             auto const tag = reader.tag();
@@ -131,9 +189,17 @@ BOOST_AUTO_TEST_CASE(write_values)
                 got_int = true;
                 BOOST_CHECK_EQUAL(message.get_int64(), 3);
                 break;
+            case 5:
+                got_uint = true;
+                BOOST_CHECK_EQUAL(message.get_uint64(), 5);
+                break;
             case 3:
                 got_double = true;
                 BOOST_CHECK_EQUAL(message.get_double(), 4.);
+                break;
+            case 2:
+                got_float = true;
+                BOOST_CHECK_EQUAL(message.get_float(), 1.1f);
                 break;
             case 1:
                 got_string = true;
@@ -145,10 +211,12 @@ BOOST_AUTO_TEST_CASE(write_values)
             }
             ++messages;
         }
-        BOOST_CHECK(messages == 4);
+        BOOST_CHECK(messages == 6);
         BOOST_CHECK(got_string);
         BOOST_CHECK(got_int);
         BOOST_CHECK(got_double);
         BOOST_CHECK(got_bool);
+        BOOST_CHECK(got_uint);
+        BOOST_CHECK(got_float);
     }
 }


### PR DESCRIPTION
small maintenance PR to reduce some compiler warnings by adding unimplemented types to the vector tile specification.