### PR TITLE
fix capture mistake in transfer generation

### DIFF
--- a/include/tool/status/progress.hpp
+++ b/include/tool/status/progress.hpp
@@ -2,6 +2,7 @@
 #define TRANSIT_TOOL_STATUS_PROGRESS_HPP_
 
 #include "tool/status/timing.hpp"
+#include <cstdint>
 #include <string>
 
 namespace transit
@@ -18,6 +19,18 @@ struct FunctionTimingGuard
 
     std::string identifier;
     Timer timer;
+};
+
+class ProgressBarGuard
+{
+  public:
+    ProgressBarGuard(std::uint32_t hundred_percent);
+    ~ProgressBarGuard();
+
+    void print(std::uint32_t current);
+  private:
+    std::uint32_t hundred_percent;
+    std::uint8_t last;
 };
 
 } // namespace statue

--- a/server/app.js
+++ b/server/app.js
@@ -9,8 +9,8 @@ var corsOptions = {maxAge : 3600e3, origin : '*'};
 module.exports =
     function() {
   var app = express();
-  // var engine = new transit.Engine("../data/berlin-gtfs");
-  var engine = new transit.Engine("../data/sf");
+  var engine = new transit.Engine("../data/berlin-gtfs");
+  //var engine = new transit.Engine("../data/sf");
   engine.plug("tile");
   engine.plug("eap");
   // allow same origin and so on

--- a/src/search/coordinate_to_stop.cpp
+++ b/src/search/coordinate_to_stop.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <boost/geometry/geometries/box.hpp>
+#include "tool/status/progress.hpp"
 
 namespace transit
 {
@@ -113,6 +114,7 @@ CoordinateToStop::all(geometric::WGS84Coordinate const &location, double const r
                                          radius;
                               }),
                  result.end());
+
 
     std::vector<value_type> as_value_type(result.size());
     std::transform(

--- a/src/tool/status/progress.cpp
+++ b/src/tool/status/progress.cpp
@@ -21,6 +21,26 @@ FunctionTimingGuard::~FunctionTimingGuard()
               << timer.seconds() << " s" << std::endl;
 }
 
+ProgressBarGuard::ProgressBarGuard(std::uint32_t hundred_percent)
+    : hundred_percent(hundred_percent), last(0)
+{
+}
+
+ProgressBarGuard::~ProgressBarGuard() { std::cout << " done." << std::endl; }
+
+void ProgressBarGuard::print(std::uint32_t current)
+{
+    auto const val = 100 * current / hundred_percent;
+    if (val != last)
+    {
+        if (val % 10 == 0)
+            std::cout << " " << val << "% " << std::flush;
+        else if (val % 2 == 0)
+            std::cout << "." << std::flush;
+        last = static_cast<std::uint8_t>(val);
+    }
+}
+
 } // namespace statue
 } // namespace tool
 } // namespace transit


### PR DESCRIPTION
This fixes a performance bug (resolves #109) in the generation of transfers.
The issue was a missing capture by reference over a capture by value, resulting in a copy of the stops vector for every iteration.