### PR TITLE
escape polyline encoding for json response

### DIFF
--- a/src/bindings/node.cpp
+++ b/src/bindings/node.cpp
@@ -200,8 +200,11 @@ void Worker::HandleOKCallback()
         }
     }();
 
+    auto result = Nan::New(std::cref(service_result_as_string)).ToLocalChecked();
+    /*
     auto result = Nan::CopyBuffer(service_result_as_string.data(), service_result_as_string.size())
                       .ToLocalChecked();
+    */
 
     const auto argc = 2u;
     v8::Local<v8::Value> argv[argc] = {Nan::Null(), std::move(result)};


### PR DESCRIPTION
The front-end on Berlin/San Francisco randomly don't show routes. It turns out that the polyline encoding wasn't properly escaped for output to json.
This PR fixes the encoding.