### PR TITLE
update documentation: verbosity, reformulate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # NEPOMUK 0.0.0
 
-  - added a csv parser for gtfs messages (see https://developers.google.com/transit/gtfs/)
-  - specified format for gtfs protocol buffer messages (see https://developers.google.com/protocol-buffers/)
-  - provides scc computation for transit networks, including a plain adaptor into a connectivity graph
-  - added mapbox vector tile 2.0 implementaiton
-  - basic routing functionality implemented
-  - basic geometric features for wgs84/web-mercator (coordinate + bounding box). Including wgs84 -> web-mercator
-  - added node bindings to expose plugin architecture
-  - added basic frontend for debug tiles
-  - added look-ups (plain, computational expensive) for coordinate to stop, stop to trip, stop to station
-  - implemented some GTFS clean-up routines
-    - implemented filtering unused stops to avoid look-up pollution
-    - connect close stops that share a name into stations
-  - services added: tile / eap
-    - tile: request debug tiles in mapbox vector tile format 2.0
-    - eap: request routes between coordinates in earliest arrival format
+  - support for parsing GTFS feeds from csv (see https://developers.google.com/transit/gtfs/)
+  - debug front-end using mapbox vector tiles specification 2.0
+    - includes detection of strongly connected components (SCC) via Tarjans algorithm
+    - visualises available transfers
+  - leaflet routing machine plugin for transit routing
+    - comes with a simple example front-end
+  - support for native module node bindings via NAN
+    - with a basic eaxmple server
+  - initial routing functionality
+  - API proposal documentation
+  - support for look-ups from coordinates to stations

--- a/documentation/developing.md
+++ b/documentation/developing.md
@@ -43,3 +43,13 @@ On adding new features, provide a concise summary of the feature and (if availab
 **Breaking Changes** have to be marked as such by adding **BREAKING** in front of them.
 Whenever a change breaks the internal fileformat and requires the files to be recreated, mark the change as **REPROCESS**.
 If new functionaity requires updating internal files, mark the features as **UPDATE**. **UPDATE** requires non-updated files to continue working, though.
+
+## Verbosity
+
+Verbosity is a central conecept in code, documentation and commit messages. In all aspects, Nepomuk should reflect a well thought through level of verbosity.
+
+ - Variable names: Ensure reasonable variable names. Think of the names as you would of an API. Anyone coming to the code later on will have to understand it. Well chosen names can guide the process of understanding.
+ - Commit Messages: Use reasonable and concise commit messages. Avoid dedicated formatting commits, if possible, and squash commits into logical units. Use `git rebase -i master` and re-order the commits if necessary.
+ - Changelog: Describe the feature in a short and precise summary. Provide links wherever appropriate to help guide discussions.
+ - Ticket any TODOs. If you think a feature could be improved later on and want to add a TODO to the code, ensure that a ticket is created for the TODO and it is linked next to the TODO in the code.
+ - Open discussions early


### PR DESCRIPTION
Update the changelog to be more descriptive.
Add formulation about verbosity to the contributing guidelines.