### PR TITLE
make bindings use static version of protobuf to allow easy usage in node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,10 @@ matrix:
 addons:
   apt:
     sources: ['ubuntu-toolchain-r-test']
-    packages: ['libprotobuf-dev','protobuf-compiler','g++-6']
+    packages: ['g++-6']
 
 before_install:
-- if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update && brew install protobuf && brew install ccache
+- if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update && brew install ccache
   ccache && PATH=$PATH:/usr/local/opt/ccache/libexec; fi
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(nepomuk_os mac)
-  link_directories(/usr/local/lib)
-  include_directories(/usr/local/include)
+#  link_directories(/usr/local/lib)
+#  include_directories(SYSTEM AFTER /usr/local/include)
 
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   message(FATAL_ERROR "Windows not yet supported")
@@ -43,7 +43,7 @@ endif()
 
 # set compile flags based on optimisation / debug mode
 add_compile_options(${CMAKE_CXX_FLAGS} -std=c++14)
-add_compile_options(${CMAKE_CXX_FLAGS} -fvisibility=hidden)
+add_compile_options(${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden)
 add_compile_options(${CMAKE_CXX_FLAGS} -fPIC)
 add_compile_options(${CMAKE_CXX_FLAGS} -W)
 add_compile_options(${CMAKE_CXX_FLAGS} -Wall)
@@ -135,6 +135,7 @@ mason_use(boost_libdate_time VERSION ${BOOST_VERSION})
 #mason_use(boost_libthread VERSION ${BOOST_VERSION})
 mason_use(boost_libsystem VERSION ${BOOST_VERSION})
 
+
 set(Boost_INCLUDE_DIRS ${MASON_PACKAGE_boost_INCLUDE_DIRS})
 set(Boost_LIBRARIES
   ${MASON_PACKAGE_boost_libfilesystem_STATIC_LIBS}
@@ -150,7 +151,12 @@ set(Boost_LIBRARIES
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 
 # Optional Protobuf + ZeroMQ networking example
-find_package(Protobuf 2.4.1 REQUIRED)
+mason_use(protobuf VERSION 3.3.0)
+set(protobuf_LIBRARIES
+  "${MASON_PACKAGE_protobuf_PREFIX}/lib/libprotobuf.a")
+set(Mason_PROTOC
+  "${MASON_PACKAGE_protobuf_PREFIX}/bin/protoc")
+include_directories(SYSTEM BEFORE ${MASON_PACKAGE_protobuf_INCLUDE_DIRS})
 
 # Register sub-projects: provide CMakeLists.txt themselves with project specifics such as dependencies
 # tool needs to be first to set proto headers

--- a/cmake/mason.cmake
+++ b/cmake/mason.cmake
@@ -1,33 +1,71 @@
-# Mason CMake
+string(RANDOM LENGTH 16 MASON_INVOCATION)
+
+# Directory where Mason packages are located; typically ends with mason_packages
+if (NOT MASON_PACKAGE_DIR)
+    set(MASON_PACKAGE_DIR "${CMAKE_SOURCE_DIR}/mason_packages")
+endif()
+
+# URL prefix of where packages are located.
+if (NOT MASON_REPOSITORY)
+    set(MASON_REPOSITORY "https://mason-binaries.s3.amazonaws.com")
+endif()
+
+# Path to Mason executable
+if (NOT MASON_COMMAND)
+    set(MASON_COMMAND "${CMAKE_SOURCE_DIR}/.mason/mason")
+endif()
+
+# Determine platform
+# we call uname -s manually here since
+# CMAKE_HOST_SYSTEM_NAME will not be defined before the project() call
+execute_process(
+    COMMAND uname -s
+    OUTPUT_VARIABLE UNAME_S
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT MASON_PLATFORM)
+    if (UNAME_S STREQUAL "Darwin")
+        set(MASON_PLATFORM "macos")
+    else()
+        set(MASON_PLATFORM "linux")
+    endif()
+endif()
+
+
+# Determine platform version string
+if(MASON_PLATFORM STREQUAL "ios")
+    set(MASON_PLATFORM_VERSION "8.0") # Deployment target version
+elseif(MASON_PLATFORM STREQUAL "android")
+    if (ANDROID_ABI STREQUAL "armeabi")
+        set(MASON_PLATFORM_VERSION "arm-v5-9")
+    elseif(ANDROID_ABI STREQUAL "arm64-v8a")
+        set(MASON_PLATFORM_VERSION "arm-v8-21")
+    elseif(ANDROID_ABI STREQUAL "x86")
+        set(MASON_PLATFORM_VERSION "x86-9")
+    elseif(ANDROID_ABI STREQUAL "x86_64")
+        set(MASON_PLATFORM_VERSION "x86-64-21")
+    elseif(ANDROID_ABI STREQUAL "mips")
+        set(MASON_PLATFORM_VERSION "mips-9")
+    elseif(ANDROID_ABI STREQUAL "mips64")
+        set(MASON_PLATFORM_VERSION "mips64-21")
+    else()
+        set(MASON_PLATFORM_VERSION "arm-v7-9")
+    endif()
+elseif(NOT MASON_PLATFORM_VERSION)
+    execute_process(
+        COMMAND uname -m
+        OUTPUT_VARIABLE MASON_PLATFORM_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(MASON_PLATFORM STREQUAL "macos")
+    set(MASON_PLATFORM "osx")
+endif()
+
+set(ENV{MASON_PLATFORM} "${MASON_PLATFORM}")
+set(ENV{MASON_PLATFORM_VERSION} "${MASON_PLATFORM_VERSION}")
 
 include(CMakeParseArguments)
-
-function(mason_detect_platform)
-    # Determine platform
-    if(NOT MASON_PLATFORM)
-        # we call uname -s manually here since
-        # CMAKE_HOST_SYSTEM_NAME will not be defined before the project() call
-        execute_process(
-            COMMAND uname -s
-            OUTPUT_VARIABLE UNAME
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-        if (UNAME STREQUAL "Darwin")
-            set(MASON_PLATFORM "osx" PARENT_SCOPE)
-        else()
-            set(MASON_PLATFORM "linux" PARENT_SCOPE)
-        endif()
-    endif()
-
-    # Determine platform version string
-    if(NOT MASON_PLATFORM_VERSION)
-        execute_process(
-            COMMAND uname -m
-            OUTPUT_VARIABLE MASON_PLATFORM_VERSION
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(MASON_PLATFORM_VERSION "${MASON_PLATFORM_VERSION}" PARENT_SCOPE)
-    endif()
-endfunction()
 
 function(mason_use _PACKAGE)
     if(NOT _PACKAGE)
@@ -65,7 +103,7 @@ function(mason_use _PACKAGE)
             if (NOT EXISTS "${_CACHE_PATH}")
                 # Download the package
                 set(_URL "${MASON_REPOSITORY}/${_SLUG}.tar.gz")
-                message("[Mason] Downloading package ${_URL}...")
+                message(STATUS "[Mason] Downloading package ${_URL}...")
 
                 set(_FAILED)
                 set(_ERROR)
@@ -85,16 +123,39 @@ function(mason_use _PACKAGE)
             endif()
 
             # Unpack the package
-            message("[Mason] Unpacking package to ${_INSTALL_PATH_RELATIVE}...")
+            message(STATUS "[Mason] Unpacking package to ${_INSTALL_PATH_RELATIVE}...")
             file(MAKE_DIRECTORY "${_INSTALL_PATH}")
             execute_process(
                 COMMAND ${CMAKE_COMMAND} -E tar xzf "${_CACHE_PATH}"
                 WORKING_DIRECTORY "${_INSTALL_PATH}")
         endif()
 
-        # Error out if there is no config file.
+        # Create a config file if it doesn't exist in the package
+        # TODO: remove this once all packages have a mason.ini file
         if(NOT EXISTS "${_INSTALL_PATH}/mason.ini")
-            message(FATAL_ERROR "[Mason] Could not find mason.ini for package ${_PACKAGE} ${_VERSION}")
+            # Change pkg-config files
+            file(GLOB_RECURSE _PKGCONFIG_FILES "${_INSTALL_PATH}/*.pc")
+            foreach(_PKGCONFIG_FILE IN ITEMS ${_PKGCONFIG_FILES})
+                file(READ "${_PKGCONFIG_FILE}" _PKGCONFIG_FILE_CONTENT)
+                string(REGEX REPLACE "(^|\n)prefix=[^\n]*" "\\1prefix=${_INSTALL_PATH}" _PKGCONFIG_FILE_CONTENT "${_PKGCONFIG_FILE_CONTENT}")
+                file(WRITE "${_PKGCONFIG_FILE}" "${_PKGCONFIG_FILE_CONTENT}")
+            endforeach()
+
+            if(NOT EXISTS "${MASON_COMMAND}")
+                message(FATAL_ERROR "[Mason] Could not find Mason command at ${MASON_COMMAND}")
+            endif()
+
+            set(_FAILED)
+            set(_ERROR)
+            execute_process(
+                COMMAND ${MASON_COMMAND} config ${_PACKAGE} ${_VERSION}
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_FILE "${_INSTALL_PATH}/mason.ini"
+                RESULT_VARIABLE _FAILED
+                ERROR_VARIABLE _ERROR)
+            if(_FAILED)
+                message(FATAL_ERROR "[Mason] Could not get configuration for package ${_PACKAGE} ${_VERSION}: ${_ERROR}")
+            endif()
         endif()
 
         set(MASON_PACKAGE_${_PACKAGE}_PREFIX "${_INSTALL_PATH}" CACHE STRING "${_PACKAGE} ${_INSTALL_PATH}" FORCE)
@@ -168,48 +229,3 @@ macro(target_add_mason_package _TARGET _VISIBILITY _PACKAGE)
     target_compile_options(${_TARGET} ${_VISIBILITY} "${MASON_PACKAGE_${_PACKAGE}_OPTIONS}")
     target_link_libraries(${_TARGET} ${_VISIBILITY} "${MASON_PACKAGE_${_PACKAGE}_LIBRARIES}")
 endmacro()
-
-# Setup
-
-string(RANDOM LENGTH 16 MASON_INVOCATION)
-
-# Read environment variables if CMake is run in command mode
-if (CMAKE_ARGC)
-    set(MASON_PLATFORM "$ENV{MASON_PLATFORM}")
-    set(MASON_PLATFORM_VERSION "$ENV{MASON_PLATFORM_VERSION}")
-    set(MASON_PACKAGE_DIR "$ENV{MASON_PACKAGE_DIR}")
-    set(MASON_REPOSITORY "$ENV{MASON_REPOSITORY}")
-endif()
-
-# Directory where Mason packages are located; typically ends with mason_packages
-if (NOT MASON_PACKAGE_DIR)
-    set(MASON_PACKAGE_DIR "${CMAKE_SOURCE_DIR}/mason_packages")
-endif()
-
-# URL prefix of where packages are located.
-if (NOT MASON_REPOSITORY)
-    set(MASON_REPOSITORY "https://mason-binaries.s3.amazonaws.com")
-endif()
-
-mason_detect_platform()
-
-# Execute commands if CMake is run in command mode
-if (CMAKE_ARGC)
-    # Collect remaining arguments for passing to mason_use
-    set(_MASON_ARGS)
-    if (${CMAKE_ARGC} LESS 5)
-        message(FATAL_ERROR "Usage: mason.sh [install|prefix] PACKAGE VERSION")
-    endif()
-
-    if (${CMAKE_ARGV3} STREQUAL "install")
-        # Install the package
-        mason_use(${CMAKE_ARGV4} VERSION ${CMAKE_ARGV5})
-    elseif (${CMAKE_ARGV3} STREQUAL "prefix")
-        set(PKG_PREFIX "${MASON_PACKAGE_DIR}/${MASON_PLATFORM}-${MASON_PLATFORM_VERSION}/${CMAKE_ARGV4}/${CMAKE_ARGV5}")
-        # CMake can't write to stdout with message()
-        execute_process(COMMAND ${CMAKE_COMMAND} -E echo "${PKG_PREFIX}")
-    else()
-        message(FATAL_ERROR "Usage: mason.sh [install|prefix] PACKAGE VERSION")
-    endif()
-
-endif()

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -1,0 +1,51 @@
+function(PROTOBUF_GENERATE_CPP HDRS SRCS)
+    # input validation
+    #if(not ARGN)
+    #    message(SEND_ERROR "Error: Need to specify source files to generate protocol buffer sources.")
+    #    return()
+    #endif()
+
+    #prepare output variables
+    set(${HDRS} "")
+    set(${SRCS} "")
+
+    # remember include paths for all pb files
+    foreach(PROTO ${ARGN})
+        get_filename_component(ABSOLUTE_PROTO ${PROTO} ABSOLUTE)
+        get_filename_component(ABSOLUTE_PATH_PROTO ${ABSOLUTE_PROTO} PATH)
+        list(FIND _proto_include_dirs "${ABSOLUTE_PATH_PROTO}" _contained)
+        if(${_contained} EQUAL -1)
+            list(APPEND _proto_include_dirs ${ABSOLUTE_PATH_PROTO})
+        endif()
+    endforeach()
+
+
+    message(STATUS "Using protoc: ${Mason_PROTOC}")
+
+    #generate .pb.h and .pb.cc for each input .proto
+    foreach(PROTO ${ARGN})
+        get_filename_component(ABSOLUTE_PROTO ${PROTO} ABSOLUTE)
+        get_filename_component(NAME_PROTO ${PROTO} NAME_WE)
+
+        # remember headers/srs for output
+        set(HEADER_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/${NAME_PROTO}.pb.h")
+        set(SRC_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/${NAME_PROTO}.pb.cc")
+
+        list(APPEND ${HDRS} ${HEADER_FILENAME})
+        list(APPEND ${SRCS} ${SRC_FILENAME})
+
+        # add so commands for generation
+        add_custom_command(
+          OUTPUT ${HEADER_FILENAME}
+                 ${SRC_FILENAME}
+          COMMAND ${Mason_PROTOC}
+          ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I ${_proto_include_dirs} ${ABSOLUTE_PROTO}
+          DEPENDS ${ABSOLUTE_PROTO}
+          COMMENT "Compiling ${ABSOLUTE_PROTO} using the protoc c++ compiler."
+          VERBATIM)
+    endforeach()
+
+    set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+    set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -16,8 +16,7 @@ add_nodejs_module(${PROJECT_NAME} node.cpp)
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "src"
     ${Boost_INCLUDE_DIRS}
-    ${protozero_INCLUDE_DIRS}
-    ${PROTOBUF_INCLUDE_DIRS})
+    ${protozero_INCLUDE_DIRS})
 
 target_link_libraries(${PROJECT_NAME}
     NEPOMUKadaptor

--- a/src/tool/CMakeLists.txt
+++ b/src/tool/CMakeLists.txt
@@ -1,5 +1,7 @@
+include(${PROJECT_SOURCE_DIR}/cmake/protoc.cmake)
+
 # define a set of sources to compile
-PROTOBUF_GENERATE_CPP(proto_SOURCES local_proto_HEADERS
+PROTOBUF_GENERATE_CPP(local_proto_HEADERS proto_SOURCES
     proto/accessibility.proto
     proto/calendar.proto
     proto/dictionary.proto
@@ -20,7 +22,9 @@ add_library(NEPOMUKproto
     ${local_proto_HEADERS})
 
 target_link_libraries(NEPOMUKproto
-    ${PROTOBUF_LIBRARIES})
+    ${protobuf_LIBRARIES})
+
+message(STATUS "Protobuf libs: ${protobuf_LIBRARIES}")
 
 # add protobuf include dir to parent scope
 set(PROTOBUF_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)


### PR DESCRIPTION
Using static libs for protobuf via mason is allowing a problem-free installation of our node bindings via npm. It comes at a price, though.

There is a heavy interaction between system includes and local includes, which seems to be confusing cmake a lot.
I had to remove the link to `/usr/local/include` for osx builds, since the inclusion kept resulting in conflicting definitions between the system wide include path and the mason dependency (see https://github.com/Project-OSRM/node-osrm/issues/212 for reference).